### PR TITLE
[fix] dry-configurable-0.16.1 ArgumentError: no receiver given

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'tdlib-schema', git: 'https://github.com/southbridgeio/tdlib-schema', branch
 gem 'jwt'
 gem 'filelock'
 gem 'patron'
+gem 'dry-configurable', '0.15.0'
 
 group :test do
   gem 'timecop'


### PR DESCRIPTION
This solves https://github.com/southbridgeio/redmine_bots/issues/69.

Ref: https://github.com/southbridgeio/tdlib-ruby/issues/62